### PR TITLE
some change with webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ npm install
 npm run dev
 ```
 
-You can use `~` to include file, `~` means project root directory
+You can use `@` to include file, `@` means project root directory
 
 ```js
-import '~/src/test.js';//include /src/test.js
+import '@/src/test.js';//include /src/test.js
 ```

--- a/develop/App.vue
+++ b/develop/App.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import {msg} from '~/src/test.js';
+import {msg} from '@/src/test.js';
 export default {
   name: 'app',
   data () {

--- a/develop/webpack.config.js
+++ b/develop/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      '~': path.resolve(__dirname, '../'),
+      '@': path.resolve(__dirname, '../'),
       'vue$': 'vue/dist/vue.esm.js'
     }
   },

--- a/develop/webpack.config.js
+++ b/develop/webpack.config.js
@@ -13,6 +13,21 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.scss$/,
+          use: [
+            'style-loader',
+            'css-loader',
+            'sass-loader'
+          ]
+      },
+      {
+         test: /\.css$/,
+         use: [
+           'style-loader',
+           'css-loader'
+         ]
+      },
+      {
         test: /\.vue$/,
         loader: 'vue-loader',
         options: {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "file-loader": "^0.9.0",
     "node-sass": "^4.5.0",
     "sass-loader": "^5.0.1",
+    "style-loader": "^0.19.0",
     "vue": "^2.3.3",
     "vue-loader": "^12.1.0",
     "vue-template-compiler": "^2.3.3",


### PR DESCRIPTION
# 为webpack添加`.css`和`.scss`引用支持

没想到脚手架竟然不带，意外意外

# 将`~`代表项目根目录改为`@`

`~`貌似和scss的关键字冲突了，改成`@`后我测试就可以正常跑起来了

所以，现在可以在`scss`文件里面通过`@import "~@/path/file.css"`来引用样式文件了。

> Note: 在`scss`语法中，`~`表示引用模块。因此`~@`表示引用`@`模块（该模块指向项目根目录）